### PR TITLE
修改css中li样式的作用域

### DIFF
--- a/Announcement/css/style.css
+++ b/Announcement/css/style.css
@@ -4,7 +4,7 @@
  * @Author URL: http://www.phoneshuo.com
  */
 
-li{margin:0; padding:0; list-style-type:none}
+#div-ann-bm li{margin:0; padding:0; list-style-type:none}
 
 .com-hd{
 	margin: 20px 0 15px;


### PR DESCRIPTION
限制style.css中li样式的作用域，避免影响Markdown生成的li，造成文章中li都没有list-style-type样式符号
