### PR TITLE
修复URL大小写问题

### DIFF
--- a/Passport/README.md
+++ b/Passport/README.md
@@ -20,7 +20,7 @@
 <?php
     $activates = array_keys(Typecho_Plugin::export()['activated']);
     if (in_array('Passport', $activates)) {
-        echo '<a href="' . Typecho_Common::url('Passport/forgot', $options->index) . '">' . '忘记密码' . '</a>';
+        echo '<a href="' . Typecho_Common::url('passport/forgot', $options->index) . '">' . '忘记密码' . '</a>';
     }
 ?>
  ```


### PR DESCRIPTION
Linux下是严格区分大小写的，忘记密码的URL从
**Passport/forgot** 更改为-> **passport/forgot**