### PR TITLE
修复 Sitemap 文章链接并支持过滤低内容标签

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@
 [RoutesHelper](RoutesHelper) | Typecho路由信息显示修改 | 1.0.3 | [doudou](https://github.com/doudoutime) | [Download](https://github.com/typecho-fans/plugins/releases/download/plugins-M_to_R/RoutesHelper.zip)
 [SCS](SCS) | 系统附件用新浪云存储SCS | 1.1.1 | [vfhky](https://github.com/vfhky) | [Download](https://github.com/typecho-fans/plugins/releases/download/plugins-S_to_Z/SCS.zip)
 [Sinauth](Sinauth) | 新浪用户授权注册帐号登录 | 1.0.0 Beta | [jimmy chaw](https://github.com/web3d) | [Download](https://github.com/typecho-fans/plugins/releases/download/plugins-S_to_Z/Sinauth.zip)
-[Sitemap](Sitemap) | 动态生成Xml标准网站地图 | 1.0.5 | [迷你日志](https://minirizhi.com), [Hanny](http://www.imhan.com) | [Download](https://github.com/typecho-fans/plugins/releases/download/plugins-S_to_Z/Sitemap.zip)
+[Sitemap](Sitemap) | 动态生成Xml标准网站地图 | 1.0.6 | [迷你日志](https://minirizhi.com), [Hanny](http://www.imhan.com) | [Download](https://github.com/typecho-fans/plugins/releases/download/plugins-S_to_Z/Sitemap.zip)
 [SlantedExtend](SlantedExtend) | [Slanted主题](https://github.com/typecho-fans/themes/blob/master/Slanted)专用自定义字段 | 1.0.0 | [DT27](https://github.com/DT27) | [Special](https://github.com/typecho-fans/plugins/releases/download/plugins-S_to_Z/SlantedExtend.zip)
 [SlimBox2](SlimBox2) | 轻量级jQuery图片灯箱弹窗 | 1.0.7 | [Ryan](https://github.com/ryanfwy), [冰剑](https://github.com/binjoo) | [Download](https://github.com/typecho-fans/plugins/releases/download/plugins-S_to_Z/SlimBox2.zip)
 [Smilies](Smilies) | Typecho定制图片表情功能 | 1.1.3 | [羽中](https://github.com/jzwalk), Willin Kan | [Download](https://github.com/typecho-fans/plugins/releases/download/plugins-S_to_Z/Smilies.zip)

--- a/Sitemap/Action.php
+++ b/Sitemap/Action.php
@@ -14,18 +14,22 @@ class Sitemap_Action extends Typecho_Widget implements Widget_Interface_Do
 		->where('table.contents.type = ?', 'page')
 		->order('table.contents.created', Typecho_Db::SORT_DESC));
 
-		$articles = $db->fetchAll($db->select()->from('table.contents')
+		$articleCount = $db->fetchObject($db->select(array('COUNT(table.contents.cid)' => 'num'))->from('table.contents')
 		->where('table.contents.status = ?', 'publish')
-		->where('table.contents.created < ?', $options->gmtTime)
-		->where('table.contents.type = ?', 'post')
-		->order('table.contents.created', Typecho_Db::SORT_DESC));
+		->where('table.contents.created < ?', $options->time)
+		->where('table.contents.type = ?', 'post'))->num;
+
+		Typecho_Widget::widget(
+			'Widget_Contents_Post_Recent@sitemapArticles',
+			'pageSize=' . max(1, (int) $articleCount)
+		)->to($articles);
 		
 		Typecho_Widget::widget('Widget_Metas_Category_List@cate')->to($cates);
-		
 
 		$tags = $db->fetchAll($db->select()->from('table.metas')
 		->where('table.metas.type = ?', 'tag')
 		->order('table.metas.mid', Typecho_Db::SORT_DESC));
+		$minTagCount = max(1, (int) $options->plugin('Sitemap')->minTagCount);
 
 		header("Content-Type: application/xml");
 		echo "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
@@ -49,26 +53,10 @@ class Sitemap_Action extends Typecho_Widget implements Widget_Interface_Do
 			echo "\t\t<priority>0.6</priority>\n";
 			echo "\t</url>\n";
 		}
-		foreach($articles AS $article) {
-			$type = $article['type'];
-			$article['categories'] = $db->fetchAll($db->select()->from('table.metas')
-					->join('table.relationships', 'table.relationships.mid = table.metas.mid')
-					->where('table.relationships.cid = ?', $article['cid'])
-					->where('table.metas.type = ?', 'category')
-					->order('table.metas.order', Typecho_Db::SORT_ASC));
-			$article['category'] = urlencode(current(Typecho_Common::arrayFlatten($article['categories'], 'slug')));
-			$article['slug'] = urlencode($article['slug']);
-			$article['date'] = new Typecho_Date($article['created']);
-			$article['year'] = $article['date']->year;
-			$article['month'] = $article['date']->month;
-			$article['day'] = $article['date']->day;
-			$routeExists = (NULL != Typecho_Router::get($type));
-			$article['pathinfo'] = $routeExists ? Typecho_Router::url($type, $article) : '#';
-			$article['permalink'] = Typecho_Common::url($article['pathinfo'], $options->index);
-
+		while($articles->next()) {
 			echo "\t<url>\n";
-			echo "\t\t<loc>".$article['permalink']."</loc>\n";
-			echo "\t\t<lastmod>".date('Y-m-d',$article['modified'])."</lastmod>\n";
+			echo "\t\t<loc>".$articles->permalink."</loc>\n";
+			echo "\t\t<lastmod>".date('Y-m-d',$articles->modified)."</lastmod>\n";
 			echo "\t\t<changefreq>always</changefreq>\n";
 			echo "\t\t<priority>0.8</priority>\n";
 			echo "\t</url>\n";
@@ -91,14 +79,16 @@ class Sitemap_Action extends Typecho_Widget implements Widget_Interface_Do
 		}
 		foreach($tags AS $tag) {
 			$type = $tag['type'];
-			$art_rt = $db->fetchRow($db->select()->from('table.contents')
+			$tagArticles = $db->fetchAll($db->select('table.contents.modified')->from('table.contents')
 					->join('table.relationships', 'table.contents.cid = table.relationships.cid')
 					->where('table.contents.status = ?', 'publish')
+					->where('table.contents.created < ?', $options->time)
+					->where('table.contents.type = ?', 'post')
 					->where('table.relationships.mid = ?', $tag['mid'])
-					->order('table.relationships.cid', Typecho_Db::SORT_DESC)
-					->limit(1));
-			// 文章的标签跳过
-            if (empty($art_rt['modified'])) continue;
+					->order('table.contents.modified', Typecho_Db::SORT_DESC)
+					->limit($minTagCount));
+			if (count($tagArticles) < $minTagCount) continue;
+			$latestTagArticle = current($tagArticles);
 					
 			$routeExists = (NULL != Typecho_Router::get($type));
 			$tag['pathinfo'] = $routeExists ? Typecho_Router::url($type, $tag) : '#';
@@ -106,7 +96,7 @@ class Sitemap_Action extends Typecho_Widget implements Widget_Interface_Do
 
 			echo "\t<url>\n";
 			echo "\t\t<loc>".$tag['permalink']."</loc>\n";
-			echo "\t\t<lastmod>".date('Y-m-d',$art_rt['modified'])."</lastmod>\n";
+			echo "\t\t<lastmod>".date('Y-m-d',$latestTagArticle['modified'])."</lastmod>\n";
 			echo "\t\t<changefreq>daily</changefreq>\n";
 			echo "\t\t<priority>0.5</priority>\n";
 			echo "\t</url>\n";

--- a/Sitemap/Plugin.php
+++ b/Sitemap/Plugin.php
@@ -6,12 +6,16 @@ if (!defined('__TYPECHO_ROOT_DIR__')) exit;
  * 
  * @package Sitemap
  * @author 迷你日志, Hanny
- * @version 1.0.5
+ * @version 1.0.6
  * @dependence 9.9.2-*
  * @link https://github.com/typecho-fans/plugins/blob/master/Sitemap
  *
  * 
- * varsion 1.0.5 at 2022--9-10 by 泽泽社长
+ * version 1.0.6 at 2026-08-15 by NHPT
+ * 使用 Typecho 内容组件生成文章永久链接
+ * 支持按标签文章数量过滤 Sitemap 中的低内容标签页
+ *
+ * version 1.0.5 at 2022-09-10 by 泽泽社长
  * 分类链接支持{directory}多级分类
  * 
  * version 1.0.4 at 2020-07-02 by Typecho Fans (合并多人修改)
@@ -62,7 +66,17 @@ class Sitemap_Plugin implements Typecho_Plugin_Interface
      * @param Typecho_Widget_Helper_Form $form 配置面板
      * @return void
      */
-    public static function config(Typecho_Widget_Helper_Form $form){}
+    public static function config(Typecho_Widget_Helper_Form $form)
+    {
+        $minTagCount = new Typecho_Widget_Helper_Form_Element_Text(
+            'minTagCount',
+            NULL,
+            '1',
+            _t('标签最少文章数'),
+            _t('仅输出文章数达到该值的标签页，默认 1 表示保留全部非空标签；建议设置为 2 或更高')
+        );
+        $form->addInput($minTagCount);
+    }
     
     /**
      * 个人用户的配置面板

--- a/Sitemap/README.md
+++ b/Sitemap/README.md
@@ -2,7 +2,7 @@
     <img src="https://typecho-fans.github.io/text-logo.svg" alt="TF Logo" title="Typecho Fans开源作品社区" align="right" height="100" />
 </a>
 
-Sitemap v1.0.5 - 社区维护版
+Sitemap v1.0.6 - 社区维护版
 ======================
 <h4 align="center">—— 动态生成符合搜索引擎收录标准的Xml格式站点地图插件，支持输出分类/标签页地址。</h4>
 
@@ -27,7 +27,8 @@ Sitemap v1.0.5 - 社区维护版
 **使用方法**：
 ##### 1. 下载本插件，放在 `usr/plugins/` 目录中，确保文件夹名为 Sitemap；
 ##### 2. 激活插件；
-##### 3. 访问http://[example].com/sitemap.xml即可看到页面效果。
+##### 3. 可在插件设置中配置“标签最少文章数”，设置为 `2` 可排除只有一篇文章的低内容标签页；
+##### 4. 访问http://[example].com/sitemap.xml即可看到页面效果。
 
 </td>
 </tr>
@@ -35,6 +36,9 @@ Sitemap v1.0.5 - 社区维护版
 
 ## 版本历史
 
+ * v1.0.6 (26-08-15 [@NHPT](https://github.com/NHPT))
+   * 使用 Typecho 内容组件生成文章永久链接，避免 Sitemap 输出需要重定向的分类路径；
+   * 支持按标签文章数量过滤低内容标签页，默认保留全部非空标签。
  * v1.0.5 (22-09-210 [@jrotty](https://github.com/jrotty))
    * 分类链接支持{directory}多级分类
  * v1.0.4 (20-7-02 [@jzwalk](https://github.com/jzwalk))


### PR DESCRIPTION
## 变更内容

- 复用 Typecho 文章组件生成永久链接，确保 Sitemap 与页面 canonical 使用相同的分类和路由规则
- 增加“标签最少文章数”配置，可排除低内容标签页；默认值为 `1`，保持现有行为
- 标签统计仅包含已发布、非未来的文章，并使用最近修改时间作为 `lastmod`
- 插件版本升级到 `1.0.6`，同步插件说明和仓库索引版本

## 问题说明

原实现自行查询文章分类并按分类 `order` 选择 slug。Typecho 1.3 的分类排序逻辑与该查询不同，多分类文章可能因此输出需要 301 重定向的 URL，而不是页面实际 canonical。插件还会无条件输出全部非空标签，无法过滤只有少量文章的低内容标签页。

## 兼容性

- 未保存新配置的已有安装按最低文章数 `1` 处理
- 新安装默认值为 `1`，不会静默移除现有标签 URL
- 需要过滤单文章标签时可将配置设置为 `2`

## 验证

- Typecho 1.2.1 + PHP 7.4 + SQLite 集成测试通过
- Typecho 1.3.0 + PHP 8.3 + SQLite 集成测试通过
- 验证多分类文章输出与核心 canonical 一致
- 验证阈值为 `2` 时排除单文章标签并保留双文章标签
- 验证旧配置不存在新字段时继续输出全部非空标签
- PHP 7.4、PHP 8.3 语法检查通过