### PR TITLE
Add TeoSeo to TESTORE.md

### DIFF
--- a/TESTORE.md
+++ b/TESTORE.md
@@ -402,6 +402,7 @@
 [TePostViews](https://inwao.com/PostViews.html) | 按点击或评论数输出热门文章插件 | 1.0.0 | [inwao world](https://inwao.com),[绛木子](https://github.com/jiangmuzi) | [下载](https://github.com/typecho-fans/plugins/releases/download/plugins-S_to_Z/TePostViews.zip)
 [TeStat](https://github.com/jiangmuzi/TeStat) | 文章浏览/点赞/运行数据统计插件 | 1.1 | [绛木子](https://github.com/jiangmuzi) | [下载](https://github.com/jiangmuzi/TeStat/archive/master.zip)
 [TeThumbnail](https://github.com/jiangmuzi/TeThumbnail) | 文章模板输出自动生成缩略图插件 | 1.0.0 | [绛木子](https://github.com/jiangmuzi) | [下载](https://github.com/jiangmuzi/TeThumbnail/archive/master.zip)
+[TeoSeo](https://github.com/Astarry-1127/TeoSeo) | Typecho 1.3 SEO/GEO 插件：自动 sitemap、IndexNow/百度推送、AI 摘要与关键词、结构化数据 | 1.3.0 | [Astarry](https://github.com/Astarry-1127) | [下载](https://github.com/Astarry-1127/TeoSeo/archive/refs/heads/main.zip)
 [TeePay](https://github.com/mhcyong/TeePay) | 自媒体付费阅读插件(免费基础版) | 1.5.4 | [胖蒜网](https://github.com/mhcyong) | [下载](https://github.com/mhcyong/TeePay/archive/master.zip)
 [TelegramNotice](https://github.com/lhl77/Typecho-Plugin-TelegramNotice) | Telegram 推送评论通知与审核（支持多 Chat ID 群发、邮箱绑定、评论回复）| 1.1.0 | [LHL](https://github.com/lhl77) | [下载](https://github.com/lhl77/Typecho-Plugin-TelegramNotice/releases/download/v1.1.0/master.zip)
 [TextEditor](https://plugins.typecho.me/plugins/text-editor.html) | 基于[MooTools](https://mootools.net)Html文章编辑器插件 | 0.3.3 | [vfasky](http://vfasky.com) | [不可用](https://github.com/typecho-fans/plugins/releases/download/plugins-S_to_Z/TextEditor.zip)


### PR DESCRIPTION
## 说明

将我的 Typecho 插件 **TeoSeo** 登记到 TESTORE.md（TeStore 插件列表）。

- **插件名**：TeoSeo
- **作者**：Astarry
- **版本**：1.3.0
- **仓库**：https://github.com/Astarry-1127/TeoSeo
- **简介**：适配 Typecho 1.3 的 SEO/GEO 插件——自动 sitemap、发布即推送（IndexNow / 百度）、AI 摘要与关键词、JSON-LD 结构化数据、og:description 清理。

请审核，谢谢！
